### PR TITLE
add missing has_wiki variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,11 @@ variable "has_projects" {
   default = false
 }
 
+variable "has_wiki" {
+  type    = bool
+  default = false
+}
+
 variable "repo_type" {
   type = string
   validation {


### PR DESCRIPTION
this module errors in tf validate for missing variable has_wiki called in the github repository resource.